### PR TITLE
Turn off delay using delayAfter option.

### DIFF
--- a/lib/express-slow-down.js
+++ b/lib/express-slow-down.js
@@ -54,7 +54,7 @@ function SlowDown(options) {
           ? options.delayAfter(req, res)
           : options.delayAfter;
 
-      if (current > delayAfter) {
+      if ((delayAfter > 0) && (current > delayAfter)) {
         const unboundedDelay = (current - delayAfter) * options.delayMs;
         delay = Math.min(unboundedDelay, options.maxDelayMs);
       }


### PR DESCRIPTION
fix the ability to turn off delay by setting delayAfter option to 0.  The fix actually allows <=0 to turn off the delay but having a delayAfter set to less than 0 doesn't have any meaning here so should do the same thing, turn off the delay.