### PR TITLE
Make it compatible with latest rate-limit-redis

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,7 @@ module.exports = {
   extends: ["eslint:recommended", "plugin:prettier/recommended"],
   env: {
     node: true,
-    es2017: true,
+    es2020: true,
   },
   overrides: [
     {

--- a/lib/express-slow-down.js
+++ b/lib/express-slow-down.js
@@ -1,9 +1,8 @@
 "use strict";
-const defaults = require("defaults");
 const MemoryStore = require("./memory-store");
 
-function SlowDown(options) {
-  options = defaults(options, {
+function SlowDown(opts) {
+  const options = {
     // window, delay, and max apply per-key unless global is set to true
     windowMs: 60 * 1000, // milliseconds - how long to keep records of requests in memory
     delayAfter: 1, // how many requests to allow through before starting to delay responses
@@ -20,14 +19,16 @@ function SlowDown(options) {
       return false;
     },
     onLimitReached: function (/*req, res, optionsUsed*/) {},
-  });
+    ...opts,
+  };
 
   // store to use for persisting rate limit data
   options.store = options.store || new MemoryStore(options.windowMs);
 
-  // ensure that the store has the incr method
+  // ensure that the store has the increment method
   if (
-    typeof options.store.incr !== "function" ||
+    (typeof options.store.incr !== "function" &&
+      typeof options.store.increment !== "function") ||
     typeof options.store.resetKey !== "function" ||
     (options.skipFailedRequests &&
       typeof options.store.decrement !== "function")
@@ -42,11 +43,7 @@ function SlowDown(options) {
 
     const key = options.keyGenerator(req, res);
 
-    options.store.incr(key, function (err, current, resetTime) {
-      if (err) {
-        return next(err);
-      }
-
+    const handleIncrement = (current, resetTime) => {
       let delay = 0;
 
       const delayAfter =
@@ -135,7 +132,24 @@ function SlowDown(options) {
       }
 
       next();
-    });
+    };
+
+    if (typeof options.store.increment !== "undefined") {
+      return options.store
+        .increment(key)
+        .then(({ totalHits, resetTime }) =>
+          handleIncrement(totalHits, resetTime)
+        )
+        .catch((err) => next(err));
+    } else {
+      options.store.incr(key, (err, current, resetTime) => {
+        if (err) {
+          next(err);
+        } else {
+          handleIncrement(current, resetTime);
+        }
+      });
+    }
   }
 
   slowDown.resetKey = options.store.resetKey.bind(options.store);

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "express-slow-down",
       "version": "1.5.0",
       "license": "MIT",
-      "dependencies": {
-        "defaults": "^1.0.3"
-      },
       "devDependencies": {
         "body-parser": "^1.20.0",
         "eslint": "^7.15.0",
@@ -1682,14 +1679,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -1888,14 +1877,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/defaults": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-      "dependencies": {
-        "clone": "^1.0.2"
       }
     },
     "node_modules/delayed-stream": {
@@ -6930,11 +6911,6 @@
         }
       }
     },
-    "clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
-    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -7089,14 +7065,6 @@
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
       "dev": true
-    },
-    "defaults": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-      "requires": {
-        "clone": "^1.0.2"
-      }
     },
     "delayed-stream": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -31,9 +31,6 @@
     "brute-force",
     "attack"
   ],
-  "dependencies": {
-    "defaults": "^1.0.3"
-  },
   "devDependencies": {
     "body-parser": "^1.20.0",
     "eslint": "^7.15.0",

--- a/test/helpers/mock-store-promise-based.js
+++ b/test/helpers/mock-store-promise-based.js
@@ -1,0 +1,30 @@
+function MockStorePromiseBased() {
+  this.store = {};
+  this.incr_was_called = false;
+  this.resetKey_was_called = false;
+  this.decrement_was_called = false;
+
+  this.increment = (key) => {
+    this.incr_was_called = true;
+    this.store[key] = (this.store[key] ?? 0) + 1;
+
+    return Promise.resolve({
+      totalHits: this.store[key],
+      resetTime: undefined,
+    });
+  };
+
+  this.decrement = (key) => {
+    this.decrement_was_called = true;
+    this.store[key] = (this.store[key] ?? 0) - 1;
+  };
+
+  this.resetKey = (key) => {
+    this.resetKey_was_called = true;
+    this.store[key] = 0;
+  };
+}
+
+module.exports = {
+  MockStorePromiseBased,
+};

--- a/test/helpers/requests.js
+++ b/test/helpers/requests.js
@@ -13,6 +13,17 @@ function expectNoDelay(
   expect(next).toHaveBeenCalled();
 }
 
+async function expectNoDelayPromise(
+  instance,
+  req = new EventEmitter(),
+  res = new EventEmitter()
+) {
+  const next = jest.fn();
+  await instance(req, res, next);
+  expect(setTimeout).not.toHaveBeenCalled();
+  expect(next).toHaveBeenCalled();
+}
+
 function expectDelay(
   instance,
   expectedDelay,
@@ -37,5 +48,6 @@ function expectDelay(
 
 module.exports = {
   expectNoDelay,
+  expectNoDelayPromise,
   expectDelay,
 };

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -1,6 +1,7 @@
 const slowDown = require("../lib/express-slow-down");
 const { MockStore, InvalidStore } = require("./helpers/mock-store");
-const { expectNoDelay } = require("./helpers/requests");
+const { MockStorePromiseBased } = require("./helpers/mock-store-promise-based");
+const { expectNoDelay, expectNoDelayPromise } = require("./helpers/requests");
 
 describe("store", () => {
   beforeEach(() => {
@@ -39,5 +40,24 @@ describe("store", () => {
     });
     limiter.resetKey("key");
     expect(store.resetKey_was_called).toBeTruthy();
+  });
+
+  describe("promise based", () => {
+    it("should call increment on the store", async () => {
+      const store = new MockStorePromiseBased();
+      expect(store.incr_was_called).toBeFalsy();
+
+      const instance = slowDown({ store });
+
+      await expectNoDelayPromise(instance);
+      expect(store.incr_was_called).toBeTruthy();
+    });
+
+    it("should call resetKey on the store", function () {
+      const store = new MockStorePromiseBased();
+      const limiter = slowDown({ store });
+      limiter.resetKey("key");
+      expect(store.resetKey_was_called).toBeTruthy();
+    });
   });
 });


### PR DESCRIPTION
This should close https://github.com/express-rate-limit/express-slow-down/issues/24

- Modify `incr` function to `increment`
- `increment` can handle promise-based store function  