### PR TITLE
fix: suppress WRN_ERL_MAX_ZERO when custom validation object is passed in

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,8 +4,8 @@
 
 ### Fixed
 
-- express-rate-limit's `WRN_ERL_MAX_ZERO` warning is not correctly suppressed
-  even when supplying a custom validations object in the config.
+- Fixed an incorrect `WRN_ERL_MAX_ZERO` warning when supplying a custom
+  validation object in the config.
 
 ## v2.0.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # express-slow-down changelog
 
+## v2.0.1
+
+### Fixed
+
+- express-rate-limit's `WRN_ERL_MAX_ZERO` warning is not correctly suppressed
+  even when supplying a custom validations object in the config.
+
 ## v2.0.0
 
 express-slow-down v2 is built on top of express-rate-limit v7.

--- a/source/slow-down.ts
+++ b/source/slow-down.ts
@@ -139,13 +139,15 @@ export const slowDown = (
 		},
 		maxDelayMs: Number.POSITIVE_INFINITY,
 		requestPropertyName: 'slowDown',
+
+		// Next the user's options are pulled in, overriding defaults from above
+		...notUndefinedOptions,
+
+		// This is a combination of the user's validate settings and our own overrides
 		validate: {
 			...validate,
 			limit: false, // We know the behavor of limit=0 changed - we depend on the new behavior!
 		},
-
-		// The following options are passed directly to `express-rate-limit`.
-		...notUndefinedOptions,
 
 		// These settings cannot be overriden.
 		limit: 0, // We want the handler to run on every request.

--- a/test/library/options-test.ts
+++ b/test/library/options-test.ts
@@ -2,6 +2,7 @@
 // Tests the parsing/handling of options passed in by the user
 
 import slowDown from '../../source/index.js'
+import { expectNoDelay } from '../helpers/requests.js'
 
 describe('options', () => {
 	beforeEach(() => {
@@ -48,6 +49,18 @@ describe('options', () => {
 
 	it('should not warn about delayMs being a number if validate.delayMs is false', () => {
 		slowDown({ delayMs: 100, validate: { delayMs: false } })
+		expect(console.warn).not.toBeCalled()
+		expect(console.error).not.toBeCalled()
+	})
+
+	it('should not warn about max being zero when validate.delayMs is false', async () => {
+		jest.spyOn(global, 'setTimeout')
+		const instance = slowDown({
+			delayAfter: 1,
+			delayMs: 100,
+			validate: { delayMs: false },
+		})
+		await expectNoDelay(instance)
 		expect(console.warn).not.toBeCalled()
 		expect(console.error).not.toBeCalled()
 	})


### PR DESCRIPTION
Fixes #46 and adds a test.