### PR TITLE
doc: replace `express-rate-limit` with `express-slow-down` in CommonJ…

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,7 +64,7 @@ Import it in a CommonJS project (`type: commonjs` or no `type` field in
 `package.json`) as follows:
 
 ```ts
-const { slowDown } = require('express-rate-limit')
+const { slowDown } = require('express-slow-down')
 ```
 
 Import it in a ESM project (`type: module` in `package.json`) as follows:


### PR DESCRIPTION
In the `README.md` file, under Usage, one of the imports was mislabeled as `express-rate-limit` instead of `express-slow-down`