### PR TITLE
chore(deps): support express 5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "node": ">= 16"
       },
       "peerDependencies": {
-        "express": ">= 4"
+        "express": "^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "prepare": "run-s compile && husky install config/husky"
   },
   "peerDependencies": {
-    "express": ">= 4"
+    "express": "^4.0.0 || ^5.0.0"
   },
   "dependencies": {
     "express-rate-limit": "7"


### PR DESCRIPTION
This pull request addresses an issue with dependency resolution in the express-slow-down package. Currently, the package specifies a peer dependency on Express >= 4, which leads to conflicts when installed in projects using Express 5.0.0-beta.3 or higher.

Error log when installing on project with express 5

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: myproject@1.0.0
npm ERR! Found: express@5.0.0-beta.3
npm ERR! node_modules/express
npm ERR!   express@"5.0.0-beta.3" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer express@">= 4" from express-slow-down@2.0.1
npm ERR! node_modules/express-slow-down
npm ERR!   express-slow-down@"*" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```