### PR TITLE
chore: express 5 beta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "node": ">= 16"
       },
       "peerDependencies": {
-        "express": "^4.0.0 || ^5.0.0"
+        "express": "4 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "prepare": "run-s compile && husky install config/husky"
   },
   "peerDependencies": {
-    "express": "^4.0.0 || ^5.0.0"
+    "express": "4 || 5 || ^5.0.0-beta.1"
   },
   "dependencies": {
     "express-rate-limit": "7"


### PR DESCRIPTION
Since #51 not working properly with express 5 beta, I just copied exact same "peerDependencies" from express-rate-limit. Now, express-rate-limit and express-slow-down are sharing same peerDeps

<https://github.com/express-rate-limit/express-rate-limit/blob/86a405d9adec8c678d319bcfdde487235c3cb721/package.json#L77C3-L77C39>