### PR TITLE
Don't bundle in express-rate-limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
   },
   "scripts": {
     "clean": "del-cli dist/ coverage/ *.log *.tmp *.bak *.tgz",
-    "build:cjs": "esbuild --platform=node --bundle --target=es2022 --format=cjs --outfile=dist/index.cjs --footer:js=\"module.exports = slowDown; module.exports.default = slowDown; module.exports.slowDown = slowDown; \" source/index.ts",
-    "build:esm": "esbuild --platform=node --bundle --target=es2022 --format=esm --outfile=dist/index.mjs source/index.ts",
+    "build:cjs": "esbuild --platform=node --bundle --target=es2022 --packages=external --format=cjs --outfile=dist/index.cjs --footer:js=\"module.exports = slowDown; module.exports.default = slowDown; module.exports.slowDown = slowDown; \" source/index.ts",
+    "build:esm": "esbuild --platform=node --bundle --target=es2022 --packages=external --format=esm --outfile=dist/index.mjs source/index.ts",
     "build:types": "dts-bundle-generator --out-file=dist/index.d.ts source/index.ts && cp dist/index.d.ts dist/index.d.cts && cp dist/index.d.ts dist/index.d.mts",
     "compile": "run-s clean build:*",
     "lint:code": "xo",


### PR DESCRIPTION
Bundling express-rate-limit in causes it to be downloaded twice by end users (because it's also a npm dependency) and prevents them from updating to a newer release of ERL without us releasing a new build of ESD.

Fixes #62

(It also shrinks our release `index.mjs` from 26K to 4.3K!)