### PR TITLE
Fix typos

### DIFF
--- a/source/slow-down.ts
+++ b/source/slow-down.ts
@@ -124,7 +124,7 @@ export const slowDown = (
 		console.warn(new ExpressSlowDownWarning('WRN_ESD_DELAYMS', message))
 	}
 
-	// Express-rate-limit will warn about enbling or disabling unknown validations,
+	// Express-rate-limit will warn about enabling or disabling unknown validations,
 	// so delete the delayMs flag (if set)
 	delete validate?.delayMs
 
@@ -146,15 +146,15 @@ export const slowDown = (
 		// This is a combination of the user's validate settings and our own overrides
 		validate: {
 			...validate,
-			limit: false, // We know the behavor of limit=0 changed - we depend on the new behavior!
+			limit: false, // We know the behavior of limit=0 changed - we depend on the new behavior!
 		},
 
-		// These settings cannot be overriden.
+		// These settings cannot be overridden.
 		limit: 0, // We want the handler to run on every request.
 		// Disable the headers, we don't want to send them.
 		legacyHeaders: false,
 		standardHeaders: false,
-		// The handler contains the slow-down logic, so don't allow it to be overriden.
+		// The handler contains the slow-down logic, so don't allow it to be overridden.
 		async handler(_request: Request, response: Response, next: NextFunction) {
 			// Get the number of requests after which we should speed-limit the client.
 			const delayAfter =

--- a/source/types.ts
+++ b/source/types.ts
@@ -39,7 +39,7 @@ export type ExtendedValidations = EnabledValidations & { delayMs?: boolean }
 /**
  * Options present in `express-rate-limit` that this package overrides.
  */
-export type OverridenOptions = {
+export type OverriddenOptions = {
 	/**
 	 * The header options are not supported, and using them will throw an error.
 	 */
@@ -54,11 +54,14 @@ export type OverridenOptions = {
 	max: never
 
 	/**
-	 * The `handler` option is overriden by the library.
+	 * The `handler` option is overridden by the library.
 	 */
 	handler: never
 }
 
+// Backwards compatibility because we shipped this with a typo.
+// may be removed in a future semver major release.
+export type OverridenOptions = OverriddenOptions
 /**
  * All the `express-slow-down` specific options.
  */
@@ -104,7 +107,7 @@ export type SlowDownOptions = {
 /**
  * The configuration options for the middleware.
  */
-export type Options = RateLimitOptions & OverridenOptions & SlowDownOptions
+export type Options = RateLimitOptions & OverriddenOptions & SlowDownOptions
 
 /**
  * The extended request object that includes information about the client's


### PR DESCRIPTION
It turns out that I misspelled 'overridden' pretty consistently. Unfortunately, part of the public types included the mistake, so there's still one misspelling here to preserve backwards compatibility. But the others should be fixed, along with a couple of other typos.